### PR TITLE
Fixed boatloads of fatal warnings with -Wall.

### DIFF
--- a/src/IR32.h
+++ b/src/IR32.h
@@ -9,7 +9,7 @@
 #include "Arduino.h"
 
 typedef struct {
-    char* tag;
+    const char* tag;
     uint16_t carrier_freq_khz;
     uint8_t duty_cycle;
     uint8_t bit_length;
@@ -24,7 +24,7 @@ typedef struct {
 } rmt_timing_t;
 
     const rmt_timing_t timing_groups[] = {
-      {0},
+      {"", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
       {"NEC", 38000, 33, 32, 0, 9000, 4500, 560, 1690, 560, 560, 560},
       {"samsung", 38000, 33, 32, 0, 4500, 4450, 560, 1600, 560, 560, 8950},
       {"LG", 38000, 33, 28, 0, 8500, 4250, 560, 1600, 560, 560, 800},

--- a/src/IRRecv.cpp
+++ b/src/IRRecv.cpp
@@ -37,6 +37,7 @@ bool IRRecv::start(gpio_num_t rx_pin)
     rmt_rx_start(_channel, 1);
     _rx_pin = rx_pin;
     _active = true;
+    return true; // FIXME: is that correct?
 }
 bool IRRecv::start(int rx_pin)
     {return start((gpio_num_t) rx_pin);}
@@ -121,16 +122,16 @@ void dump_item(rmt_item32_t* item, size_t sz)
  
 uint32_t IRRecv::read(char* &timingGroup, bool preferredOnly)
 {
-    if (!available()) return NULL;
+    if (!available()) return 0;
          
     size_t rx_size = 0;
     rmt_item32_t* item = (rmt_item32_t*) xRingbufferReceive(_rb, &rx_size, RMT_RX_BUF_WAIT);
-    if (!item) return NULL;
+    if (!item) return 0;
     //after parsing the data, clear space in the ringbuffer.
     vRingbufferReturnItem(_rb, (void*) item);
     //dump_item(item,rx_size); 
     uint32_t rx_data;
-    uint8_t found_timing;
+    uint8_t found_timing = 0;
     for (uint8_t timing : _preferred) {
         rx_data = rx_parse_items(item, rx_size / 4, timing);
         if (rx_data) {
@@ -151,7 +152,7 @@ uint32_t IRRecv::read(char* &timingGroup, bool preferredOnly)
         }
     }
     if (found_timing) {
-        timingGroup = timing_groups[found_timing].tag;
+        timingGroup = (char *)timing_groups[found_timing].tag;
     }
     return rx_data;
 }    
@@ -165,6 +166,7 @@ uint8_t timingGroupElement(char* tag)
        if(timing.tag == tag) return counter;
        counter++;
    }
+   return counter; // FIXME: is this correct?
 }
 
 bool IRRecv::inPrefVector(uint8_t element)

--- a/src/IRSend.cpp
+++ b/src/IRSend.cpp
@@ -18,7 +18,7 @@ IRSend::IRSend(rmt_channel_t channel)
     _tx_pin = GPIO_NUM_MAX;
 }
 
-uint8_t findGroup(char* timingGroup)
+uint8_t findGroup(const char* timingGroup)
 {
     uint8_t counter = 0;
     for (rmt_timing_t timing : timing_groups) {
@@ -47,9 +47,10 @@ bool IRSend::startRMT(uint8_t timing)
     if (rmt_driver_install(rmt_tx.channel, 0, 0) != ESP_OK) return false;
     if (rmt_set_pin(_channel, RMT_MODE_TX, _tx_pin) != ESP_OK) return false;
     _timing = timing;
+    return true; // FIXME: is that correct?
 }
 
-bool IRSend::start(gpio_num_t tx_pin, char* timingGroup)
+bool IRSend::start(gpio_num_t tx_pin, const char* timingGroup)
 {
     if (tx_pin > 33) {
        log_e("Invalid pin for RMT TX: %d", tx_pin);
@@ -63,10 +64,11 @@ bool IRSend::start(gpio_num_t tx_pin, char* timingGroup)
     _tx_pin = tx_pin;
     if (!startRMT(_timing)) return false;
     _active = true;
+    return true; // FIXME: is that correct?
 }
 bool IRSend::start(gpio_num_t tx_pin, String timingGroup)
     {return start(tx_pin, timingGroup.c_str());}
-bool IRSend::start(int tx_pin, char* timingGroup)
+bool IRSend::start(int tx_pin, const char* timingGroup)
     {return start((gpio_num_t)tx_pin, timingGroup);}
 bool IRSend::start(int tx_pin, String timingGroup)
     {return start((gpio_num_t)tx_pin, timingGroup.c_str());}
@@ -144,15 +146,16 @@ bool IRSend::send(uint32_t code, uint8_t timing)
     for (int x=0; x<timing_groups[timing].bit_length+3; x++) {
         //Serial.printf("item: %d  time0: %d  time1: %d\n", x, item[x].duration0, item[x].duration1);
     }
-	int item_num = timing_groups[timing].bit_length + 2;
-	if (rmt_write_items(_channel, item, item_num, true) != ESP_OK) return false;
-	rmt_wait_tx_done(_channel,RMT_TX_WAIT);
-	free(item);
+    int item_num = timing_groups[timing].bit_length + 2;
+    if (rmt_write_items(_channel, item, item_num, true) != ESP_OK) return false;
+    rmt_wait_tx_done(_channel,RMT_TX_WAIT);
+    free(item);
+    return true; // FIXME: is that correct?
 }
 bool IRSend::send(uint32_t code, char* timingGroup)
-    {send(code, findGroup(timingGroup));}
+    { return send(code, findGroup(timingGroup)); }
 bool IRSend::send(uint32_t code)
-    {send(code, _timing);}
+    { return send(code, _timing); }
 
 void IRSend::stop() 
 {

--- a/src/IRSend.h
+++ b/src/IRSend.h
@@ -10,8 +10,8 @@ class IRSend
   public:
     IRSend(rmt_channel_t channel=RMT_CHANNEL_1);
     bool startRMT(uint8_t timing);
-    bool start(int tx_pin, char* timingGroup = "NEC");
-    bool start(gpio_num_t tx_pin, char* timingGroup);
+    bool start(int tx_pin, const char* timingGroup = "NEC");
+    bool start(gpio_num_t tx_pin, const char* timingGroup);
     bool start(int tx_pin, String timingGroup);
     bool start(gpio_num_t tx_pin, String timingGroup);
     bool send(uint32_t code);


### PR DESCRIPTION
C++ now requires explicit use of char * vs const char *
Cannot return NULL instead of 0
found_timing potentially unitialized warning.
many codepaths that require return but were not providing explicit
return values (please check FIXMEs)